### PR TITLE
Add comprehensive CSV balance test

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -1,0 +1,18 @@
+name: Go Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.21'
+    - name: Run tests
+      run: go test ./...

--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ go.work.sum
 # .vscode/
 
 *.csv
+!testdata/*.csv

--- a/main.go
+++ b/main.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	// koinlyDateFormat defines the date format required by Koinly CSV.
-	koinlyDateFormat  = "2006-01-02 15:04:05 Z"
+	koinlyDateFormat = "2006-01-02 15:04:05 Z"
 	// phoenixDateFormat defines the date format used in Phoenix CSV exports.
 	phoenixDateFormat = "2006-01-02T15:04:05.999Z"
 )
@@ -41,13 +41,13 @@ type KoinlyRecord struct {
 
 // PhoenixRecord represents a single row in the Phoenix CSV file.
 type PhoenixRecord struct {
-	Timestamp      time.Time
-	Type           string
+	Timestamp       time.Time
+	Type            string
 	AmountMillisats int64
-	MiningFeeSat   int64
-	ServiceFeeMsat int64
-	TransactionID  string
-	Description    string
+	MiningFeeSat    int64
+	ServiceFeeMsat  int64
+	TransactionID   string
+	Description     string
 }
 
 func main() {
@@ -190,13 +190,13 @@ func parsePhoenixRecord(record []string) (*PhoenixRecord, error) {
 	}
 
 	return &PhoenixRecord{
-		Timestamp:      timestamp,
-		Type:           record[2],
+		Timestamp:       timestamp,
+		Type:            record[2],
 		AmountMillisats: amountMillisats,
-		MiningFeeSat:   miningFeeSat,
-		ServiceFeeMsat: serviceFeeMsat,
-		TransactionID:  record[11],
-		Description:    record[13],
+		MiningFeeSat:    miningFeeSat,
+		ServiceFeeMsat:  serviceFeeMsat,
+		TransactionID:   record[11],
+		Description:     record[13],
 	}, nil
 }
 
@@ -284,7 +284,3 @@ func (k *KoinlyRecord) toStringSlice() []string {
 		k.TxHash,
 	}
 }
-
-
-
-

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"math"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestParsePhoenixRecord(t *testing.T) {
+	record := []string{
+		"2024-05-01T12:00:00.000Z", // timestamp
+		"unused1",
+		"lightning_received", // type
+		"123456789",          // amount_msat
+		"unused2",
+		"unused3",
+		"0", // mining fee sat
+		"unused4",
+		"0", // service fee msat
+		"unused5",
+		"unused6",
+		"txid123", // transaction id
+		"unused7",
+		"test description", // description
+	}
+	p, err := parsePhoenixRecord(record)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !p.Timestamp.Equal(time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC)) {
+		t.Errorf("timestamp parsed incorrectly: %v", p.Timestamp)
+	}
+	if p.Type != "lightning_received" || p.AmountMillisats != 123456789 || p.MiningFeeSat != 0 || p.ServiceFeeMsat != 0 || p.TransactionID != "txid123" || p.Description != "test description" {
+		t.Errorf("parsed struct mismatch: %+v", p)
+	}
+}
+
+func TestToKoinlyRecordLightningReceived(t *testing.T) {
+	p := &PhoenixRecord{
+		Timestamp:       time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC),
+		Type:            "lightning_received",
+		AmountMillisats: 1000000000, // 1,000,000 sats
+		TransactionID:   "tx1",
+		Description:     "desc",
+	}
+	k := toKoinlyRecord(p)
+	if k.ReceivedAmount != "0.01000000" || k.ReceivedCurrency != "BTC" || k.Label != "lightning" {
+		t.Errorf("unexpected koinly record: %+v", k)
+	}
+}
+
+func TestToKoinlyRecordLightningSent(t *testing.T) {
+	p := &PhoenixRecord{
+		Timestamp:       time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC),
+		Type:            "lightning_sent",
+		AmountMillisats: -200000000, // -200,000 sats
+		TransactionID:   "tx2",
+		Description:     "desc",
+	}
+	k := toKoinlyRecord(p)
+	if k.SentAmount != "0.00200000" || k.SentCurrency != "BTC" || k.Label != "lightning" {
+		t.Errorf("unexpected koinly record: %+v", k)
+	}
+}
+
+func TestToKoinlyRecordChannelClose(t *testing.T) {
+	p := &PhoenixRecord{
+		Timestamp:       time.Date(2024, 5, 1, 12, 0, 0, 0, time.UTC),
+		Type:            "channel_close",
+		AmountMillisats: -150000, // -150 sats
+		TransactionID:   "tx3",
+		Description:     "desc",
+	}
+	k := toKoinlyRecord(p)
+	if k.FeeAmount != "0.00000150" || k.FeeCurrency != "BTC" || k.Label != "cost" {
+		t.Errorf("unexpected koinly record: %+v", k)
+	}
+}
+
+func TestFinalBalanceSampleCSV(t *testing.T) {
+	records, err := readPhoenixCSV("testdata/sample_phoenix.csv")
+	if err != nil {
+		t.Fatalf("failed to read csv: %v", err)
+	}
+	var total float64
+	for _, p := range records {
+		k := toKoinlyRecord(p)
+		if k.ReceivedAmount != "" {
+			v, err := strconv.ParseFloat(k.ReceivedAmount, 64)
+			if err != nil {
+				t.Fatalf("bad received amount: %v", err)
+			}
+			total += v
+		}
+		if k.SentAmount != "" {
+			v, err := strconv.ParseFloat(k.SentAmount, 64)
+			if err != nil {
+				t.Fatalf("bad sent amount: %v", err)
+			}
+			total -= v
+		}
+		if k.FeeAmount != "" {
+			v, err := strconv.ParseFloat(k.FeeAmount, 64)
+			if err != nil {
+				t.Fatalf("bad fee amount: %v", err)
+			}
+			total -= v
+		}
+	}
+	expected := 0.00157
+	if math.Abs(total-expected) > 1e-8 {
+		t.Errorf("expected final balance %.8f BTC, got %.8f BTC", expected, total)
+	}
+}

--- a/testdata/sample_phoenix.csv
+++ b/testdata/sample_phoenix.csv
@@ -1,0 +1,7 @@
+Timestamp,ref,type,amount_msat,unused1,unused2,MiningFeeSat,unused3,ServiceFeeMsat,unused4,unused5,transaction_id,unused6,description
+2025-01-01T00:00:00.000Z,foo,lightning_received,50000000,bar,baz,0,x,0,y,z,tx1,zz,First receive
+2025-01-02T00:00:00.000Z,foo,lightning_sent,-20000000,bar,baz,10,x,0,y,z,tx2,zz,Sent payment
+2025-01-03T00:00:00.000Z,foo,swap_in,100000000,bar,baz,0,x,0,y,z,tx3,zz,Swap in
+2025-01-04T00:00:00.000Z,foo,swap_out,-50000000,bar,baz,5,x,2000,y,z,tx4,zz,Swap out
+2025-01-05T00:00:00.000Z,foo,channel_open,80000000,bar,baz,0,x,0,y,z,tx5,zz,Open channel
+2025-01-06T00:00:00.000Z,foo,channel_close,-3000000,bar,baz,3,x,0,y,z,tx6,zz,Close channel


### PR DESCRIPTION
## Summary
- allow tracking CSV files under `testdata/`
- add test CSV containing mixed transaction types
- verify net BTC balance from sample CSV

## Testing
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_68684aa65d988328bf984d3631594397