### PR TITLE
Add rounding cost tracking

### DIFF
--- a/.github/workflows/go-tests.yml
+++ b/.github/workflows/go-tests.yml
@@ -13,6 +13,6 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v5
       with:
-        go-version: '1.21'
+        go-version-file: 'go.mod'
     - name: Run tests
       run: go test ./...

--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ go.work.sum
 # Build artifacts
 phoenix-koinly-converter
 web/main.wasm
-web/wasm_exec.js
+web/wasm_exec.jsmain

--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,4 @@ go.work.sum
 # Build artifacts
 phoenix-koinly-converter
 web/main.wasm
-web/wasm_exec.jsmain
+web/wasm_exec.js

--- a/cmd/wasm/main.go
+++ b/cmd/wasm/main.go
@@ -17,13 +17,18 @@ func convertPhoenixToKoinly(this js.Value, args []js.Value) interface{} {
 	}
 	inputCSV := args[0].String()
 
+	addRoundingCost := false
+	if len(args) > 1 && args[1].Truthy() {
+		addRoundingCost = args[1].Bool()
+	}
+
 	r := strings.NewReader(inputCSV)
 	var buf bytes.Buffer
 
 	// Enable verbose if needed, though we don't capture logs here easily unless we redirect log output.
 	// converter.Verbose = true
 
-	if err := converter.Convert(r, &buf); err != nil {
+	if err := converter.Convert(r, &buf, addRoundingCost); err != nil {
 		return fmt.Sprintf("Error converting: %v", err)
 	}
 

--- a/main.go
+++ b/main.go
@@ -9,8 +9,11 @@ import (
 )
 
 func main() {
+
 	// Define command line flags.
 	flag.BoolVar(&converter.Verbose, "v", false, "Enable verbose logging for debugging.")
+	addRoundingCost := flag.Bool("r", false, "Add a cost entry adjusting for rounding differences.")
+	flag.BoolVar(addRoundingCost, "rounding-cost", false, "Alias for -r")
 	flag.Parse() // Parse command-line arguments.
 
 	// Check if a file path is provided after parsing flags.
@@ -32,7 +35,7 @@ func main() {
 	}
 	defer koinlyFile.Close()
 
-	if err := converter.Convert(f, koinlyFile); err != nil {
+	if err := converter.Convert(f, koinlyFile, *addRoundingCost); err != nil {
 		log.Fatalf("Conversion failed: %v", err)
 	}
 

--- a/web/app.js
+++ b/web/app.js
@@ -51,8 +51,9 @@ function handleFile(file) {
     const reader = new FileReader();
     reader.onload = async (e) => {
         const content = e.target.result;
+        const addRoundingCost = document.getElementById('rounding-checkbox').checked;
         try {
-            const output = convertPhoenixToKoinly(content);
+            const output = convertPhoenixToKoinly(content, addRoundingCost);
 
             if (output.startsWith("Error")) {
                 showStatus(output, "error");

--- a/web/index.html
+++ b/web/index.html
@@ -26,7 +26,10 @@
             </div>
 
             <div class="options">
-                <!-- Options can go here -->
+                <div class="checkbox-group">
+                    <input type="checkbox" id="rounding-checkbox">
+                    <label for="rounding-checkbox">Adjust for rounding differences (adds a cost transaction)</label>
+                </div>
             </div>
 
             <div id="status" class="status hidden"></div>


### PR DESCRIPTION
## Summary
- add `-rounding-cost` flag
- compute rounding differences for each transaction
- optionally append a cost record for sats lost to rounding
- update tests for new behavior and add a rounding diff test

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_686a85bc149883288b71d7edc064ed08